### PR TITLE
Fix issues #1, #2, add tests, implement standard markdown image links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ MANIFEST
 # Visual Studio Code
 .vscode/
 
+# Sandbox
+sandbox/
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# Visual Studio Code
+.vscode/
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/markdown2dash/src/renderer.py
+++ b/markdown2dash/src/renderer.py
@@ -10,10 +10,10 @@ from .decorators import class_name
 from .utils import create_heading_id
 
 # -- For image shape decoding
-import cv2
-import numpy as np
 from urllib.request import urlopen
 from dash import get_app
+import imagesize
+import io
 
 # noinspection PyMethodMayBeStatic
 class DashRenderer(HTMLRenderer):
@@ -59,22 +59,21 @@ class DashRenderer(HTMLRenderer):
 
     @class_name
     def image(self, text: str, url: str, title=None):
-        def get_image_width(url, readFlag=cv2.IMREAD_COLOR, default=200):
-            # https://stackoverflow.com/questions/21061814/how-can-i-read-an-image-from-an-internet-url-in-python-cv2-scikit-image-and-mah
+        def get_image_width(url, default=200):
             if url[0] == "/":   # A relative URL
                 try:
                     flaskroot = get_app().server.root_path
                     filepath = flaskroot + url
-                    image = cv2.imread(filepath) 
-                    return image.shape[1]
+                    width, _height = imagesize.get(filepath)
+                    return width
                 except:
                     return default
             else:               # Assume an actual url
                 try:
-                    resp = urlopen(url)
-                    npimage = np.asarray(bytearray(resp.read()), dtype="uint8")
-                    image = cv2.imdecode(npimage, readFlag)
-                    return image.shape[1]
+                    raw = urlopen(str(url)).read()
+                    fhandle = io.BytesIO(raw)
+                    width, _height = imagesize.get(fhandle)
+                    return width
                 except:
                     return default
 

--- a/markdown2dash/src/renderer.py
+++ b/markdown2dash/src/renderer.py
@@ -32,11 +32,11 @@ class DashRenderer(HTMLRenderer):
 
     @class_name
     def emphasis(self, text: str) -> Component:
-        return dmc.Text(text, fs="italic")
+        return dmc.Text(text, fs="italic", style={"display":"inline"})
 
     @class_name
     def strong(self, text: str) -> Component:
-        return dmc.Text(text, weight="bold")
+        return dmc.Text(text, weight="bold" , style={"display":"inline"})
 
     @class_name
     def codespan(self, text: str) -> Component:

--- a/markdown2dash/src/renderer.py
+++ b/markdown2dash/src/renderer.py
@@ -69,8 +69,8 @@ class DashRenderer(HTMLRenderer):
 
     @class_name
     def list_item(self, text: str) -> Component:
-        if isinstance(text[0], list):
-            text = text[0]
+        if isinstance(text, list):
+            text = [item[0] if isinstance(item, list) else item for item in text]
         return dmc.ListItem(text)
 
     @class_name

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -3,17 +3,23 @@ import tests.testutils as tu
 
 def test1():
     md = '''
-    # Header
+# Header
 
-    Text.
-    Continuation
-    '''
+Lorem
+ipsum
+'''
     layout = parse(md)
     d = tu.todict(layout)
     assert(
-        d == {
-            'type': 'Code', 
-            # -- A single \n does not appear to trigger a line break, but two do
-            'children': {'type': 'str', 'children': '# Header\n\nText.\nContinuation'}
-        }
+        d == [
+            {
+                'name': 'Title', 
+                'children': 'Header'
+            }, 
+            {
+                'name': 'Text', 
+                # A single \n does not appear to trigger a line break in rendered output
+                'children': ['Lorem', '\n', 'ipsum']
+            }
+        ]
     )

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,6 +1,7 @@
-# IN case it is being run as a submodule
+# In case it is being run as a submodule
 import sys
-sys.path.append('./markdown2dash')
+if './markdown2dash' not in sys.path:
+    sys.path.append('./markdown2dash')
 
 from markdown2dash import parse
 import tests.testutils as tu

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,0 +1,19 @@
+from markdown2dash import parse
+import tests.testutils as tu
+
+def test1():
+    md = '''
+    # Header
+
+    Text.
+    Continuation
+    '''
+    layout = parse(md)
+    d = tu.todict(layout)
+    assert(
+        d == {
+            'type': 'Code', 
+            # -- A single \n does not appear to trigger a line break, but two do
+            'children': {'type': 'str', 'children': '# Header\n\nText.\nContinuation'}
+        }
+    )

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -14,7 +14,8 @@ ipsum
         d, [
             {
                 'name': 'Title', 
-                'children': 'Header'
+                'children': 'Header',
+                'order': 1,
             }, 
             {
                 'name': 'Text', 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,3 +1,7 @@
+# IN case it is being run as a submodule
+import sys
+sys.path.append('./markdown2dash')
+
 from markdown2dash import parse
 import tests.testutils as tu
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -10,8 +10,8 @@ ipsum
 '''
     layout = parse(md)
     d = tu.todict(layout)
-    assert(
-        d == [
+    tu.dcompare(
+        d, [
             {
                 'name': 'Title', 
                 'children': 'Header'

--- a/tests/test_em_strong.py
+++ b/tests/test_em_strong.py
@@ -12,14 +12,15 @@ Normal, *em*, **strong**, ***strong em***, normal
             'name': 'Text', 
             'children': [
                 'Normal, ', 
-                {'name': 'Text', 'children': 'em', 'fs':'italic'}, 
+                {'name': 'Text', 'children': 'em', 'fs': 'italic', 'style': {'display': 'inline'}}, 
                 ', ', 
-                {'name': 'Text', 'children': 'strong', 'weight':'bold'}, 
+                {'name': 'Text', 'children': 'strong', 'weight': 'bold', 'style': {'display': 'inline'}}, 
                 ', ', 
                 {
                     'name': 'Text', 
                     'fs':'italic',
-                    'children': {'name': 'Text', 'children': 'strong em', 'weight':'bold'}
+                    'children': {'name': 'Text', 'children': 'strong em', 'weight':'bold', 'style': {'display': 'inline'}},
+                    'style': {'display': 'inline'}
                 }, 
                 ', normal'
             ]

--- a/tests/test_em_strong.py
+++ b/tests/test_em_strong.py
@@ -1,3 +1,7 @@
+# In case it is being run as a submodule
+import sys
+sys.path.append('./markdown2dash')
+
 from markdown2dash import parse
 import tests.testutils as tu
 

--- a/tests/test_em_strong.py
+++ b/tests/test_em_strong.py
@@ -7,8 +7,8 @@ Normal, *em*, **strong**, ***strong em***, normal
 '''
     layout = parse(md)
     d = tu.todict(layout)
-    assert(
-        d == {
+    tu.dcompare(
+        d, {
             'name': 'Text', 
             'children': [
                 'Normal, ', 

--- a/tests/test_em_strong.py
+++ b/tests/test_em_strong.py
@@ -1,0 +1,27 @@
+from markdown2dash import parse
+import tests.testutils as tu
+
+def test1():
+    md = '''
+Normal, *em*, **strong**, ***strong em***, normal
+'''
+    layout = parse(md)
+    d = tu.todict(layout)
+    assert(
+        d == {
+            'name': 'Text', 
+            'children': [
+                'Normal, ', 
+                {'name': 'Text', 'children': 'em', 'fs':'italic'}, 
+                ', ', 
+                {'name': 'Text', 'children': 'strong', 'weight':'bold'}, 
+                ', ', 
+                {
+                    'name': 'Text', 
+                    'fs':'italic',
+                    'children': {'name': 'Text', 'children': 'strong em', 'weight':'bold'}
+                }, 
+                ', normal'
+            ]
+        }
+    )

--- a/tests/test_em_strong.py
+++ b/tests/test_em_strong.py
@@ -1,6 +1,7 @@
 # In case it is being run as a submodule
 import sys
-sys.path.append('./markdown2dash')
+if './markdown2dash' not in sys.path:
+    sys.path.append('./markdown2dash')
 
 from markdown2dash import parse
 import tests.testutils as tu

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,24 @@
+from markdown2dash import parse
+import tests.testutils as tu
+
+def test1():
+    md = '''
+### XKCD  on Python
+![XKCD on Python](https://imgs.xkcd.com/comics/python_environment_2x.png)
+'''
+    layout = parse(md)
+    d = tu.todict(layout)
+    tu.dcompare(
+        d, [
+            {'name': 'Title', 'children': 'XKCD  on Python', 'order':3}, 
+            {
+                'name': 'Text', 
+                'children': {
+                    'name': 'Image', 
+                    'src': 'https://imgs.xkcd.com/comics/python_environment_2x.png', 
+                    'alt': 'XKCD on Python', 
+                    'styles': {'imageWrapper': {'width': 983}}
+                }
+            }
+        ]
+    )

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,3 +1,7 @@
+# In case it is being run as a submodule
+import sys
+sys.path.append('./markdown2dash')
+
 from markdown2dash import parse
 import tests.testutils as tu
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,6 +1,7 @@
 # In case it is being run as a submodule
 import sys
-sys.path.append('./markdown2dash')
+if './markdown2dash' not in sys.path:
+    sys.path.append('./markdown2dash')
 
 from markdown2dash import parse
 import tests.testutils as tu

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,3 +1,7 @@
+# In case it is being run as a submodule
+import sys
+sys.path.append('./markdown2dash')
+
 from markdown2dash import parse
 import tests.testutils as tu
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -10,8 +10,8 @@ Prior line
 '''
     layout = parse(md)
     d = tu.todict(layout)
-    assert(
-        d == [
+    tu.dcompare(
+        d,  [
             {
                 'name': 'Text', 
                 'children': 'Prior line'
@@ -25,4 +25,38 @@ Prior line
                 ]
             }
         ]
+    )
+# --------------------------------------------------------
+def test2():
+    "Nested unordered list"
+    md = '''
+* Level 1 a
+   * Level 2 a
+   * Level 2 b
+* Level 1 b
+'''
+    layout = parse(md)
+    d = tu.todict(layout)
+    tu.dcompare(
+        d, {
+            'name': 'List', 
+            'children': [
+                {
+                    'name': 'ListItem', 
+                    'children': [
+                        'Level 1 a', 
+                        {
+                            'name': 'List', 
+                            'children': [
+                                {'name': 'ListItem', 'children': 'Level 2 a'}, 
+                                {'name': 'ListItem', 'children': 'Level 2 b'}
+                            ], 
+                            'type': 'unordered'
+                        }
+                    ]
+                }, 
+                {'name': 'ListItem', 'children': 'Level 1 b'}
+            ], 
+            'type': 'unordered'
+        }
     )

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -60,3 +60,42 @@ def test2():
             'type': 'unordered'
         }
     )
+# --------------------------------------------------------
+def test3():
+    "Combination of nesting, emphasis and continuation lines"
+    md = '''
+* Item 1 *emphasis* normal
+with continuation
+    * Level 2
+with continuation
+* Item 2
+'''
+    layout = parse(md)
+    d = tu.todict(layout)
+    tu.dcompare(
+        d, {
+            'name': 'List', 
+            'children': [
+                {
+                    'name': 'ListItem', 
+                    'children': [
+                        'Item 1 ', 
+                        {'name': 'Text', 'children': 'emphasis', 'fs': 'italic', 'style': {'display': 'inline'}}, 
+                        ' normal', 
+                        '\n', 
+                        'with continuation', 
+                        {
+                            'name': 'List', 
+                            'children': {
+                                'name': 'ListItem', 
+                                'children': ['Level 2', '\n', 'with continuation']
+                            }, 
+                            'type': 'unordered'
+                        }
+                    ]
+                }, 
+                {'name': 'ListItem', 'children': 'Item 2'}
+            ], 
+            'type': 'unordered'
+        }
+    )

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,0 +1,28 @@
+from markdown2dash import parse
+import tests.testutils as tu
+
+def test1():
+    "Single-level unordered list"
+    md = '''
+Prior line
+* Item 1
+* Item 2
+'''
+    layout = parse(md)
+    d = tu.todict(layout)
+    assert(
+        d == [
+            {
+                'name': 'Text', 
+                'children': 'Prior line'
+            }, 
+            {
+                'name': 'List',
+                'type': 'unordered', 
+                'children': [
+                    {'name': 'ListItem', 'children': 'Item 1'},
+                    {'name': 'ListItem', 'children': 'Item 2'}
+                ]
+            }
+        ]
+    )

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,6 +1,7 @@
 # In case it is being run as a submodule
 import sys
-sys.path.append('./markdown2dash')
+if './markdown2dash' not in sys.path:
+    sys.path.append('./markdown2dash')
 
 from markdown2dash import parse
 import tests.testutils as tu

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -16,4 +16,8 @@ def todict(layout):
         }
         if hasattr(layout, 'type'):
             d.update({"type":layout.type})
+        if hasattr(layout, 'fs'):
+            d.update({"fs":layout.fs})
+        if hasattr(layout, 'weight'):
+            d.update({"weight":layout.weight})
         return d

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,0 +1,19 @@
+"Utilities to support unit tests"
+
+def todict(layout):
+    "Simple partial converter of layout structure to dict"
+    ltype = type(layout).__name__
+    if isinstance(layout, list):
+        if len(layout) == 1:
+            return todict(layout[0])
+        else:
+            children = [todict(item) for item in layout]
+    elif not hasattr(layout, 'children'):
+        children = str(layout)
+    else:
+        children = todict(layout.children)
+    d = {
+        "type": ltype,
+        "children" : children
+    }
+    return d

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -7,20 +7,31 @@ def todict(layout):
             return todict(layout[0])
         else:
             return [todict(item) for item in layout]
-    elif not hasattr(layout, 'children'):
-        return str(layout)
-    else:
+    elif hasattr(layout, '__module__') and layout.__module__.split('.')[0] == "dash_mantine_components":   #hasattr(layout, 'children'):
         d = {
             "name": type(layout).__name__,
-            "children" : todict(layout.children)
         }
+        if hasattr(layout, 'children'):
+            d.update({"children":todict(layout.children)})
         if hasattr(layout, 'type'):
             d.update({"type":layout.type})
         if hasattr(layout, 'fs'):
             d.update({"fs":layout.fs})
         if hasattr(layout, 'weight'):
             d.update({"weight":layout.weight})
+        if hasattr(layout, 'src'):
+            d.update({"src":layout.src})
+        if hasattr(layout, 'alt'):
+            d.update({"alt":layout.alt})
+        if hasattr(layout, 'style'):
+            d.update({"style":layout.style})
+        if hasattr(layout, 'styles'):
+            d.update({"styles":layout.styles})
+        if hasattr(layout, 'order'):
+            d.update({"order":layout.order})
         return d
+    else:
+        return str(layout)
 
 def dcompare(d1, d2, path="(root)"):
     "Comparison of data structures that gives useful info on where a mismatch is"

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -2,18 +2,18 @@
 
 def todict(layout):
     "Simple partial converter of layout structure to dict"
-    ltype = type(layout).__name__
     if isinstance(layout, list):
         if len(layout) == 1:
             return todict(layout[0])
         else:
-            children = [todict(item) for item in layout]
+            return [todict(item) for item in layout]
     elif not hasattr(layout, 'children'):
-        children = str(layout)
+        return str(layout)
     else:
-        children = todict(layout.children)
-    d = {
-        "type": ltype,
-        "children" : children
-    }
-    return d
+        d = {
+            "name": type(layout).__name__,
+            "children" : todict(layout.children)
+        }
+        if hasattr(layout, 'type'):
+            d.update({"type":layout.type})
+        return d

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -21,3 +21,20 @@ def todict(layout):
         if hasattr(layout, 'weight'):
             d.update({"weight":layout.weight})
         return d
+
+def dcompare(d1, d2, path="(root)"):
+    "Comparison of data structures that gives useful info on where a mismatch is"
+    if isinstance(d1, list):
+        if not isinstance(d2, list):
+            assert False, f"At {path}, d1 is a list, d2 is not"
+        if len(d1) != len(d2):
+            assert False, f"At {path}, d1 length={len(d1)}, d2 length is {len(d2)}"
+        for index, (item1, item2) in enumerate(zip(d1, d2)):
+            dcompare(item1, item2, f"{path}/[{index}]")
+    elif isinstance(d1, dict):
+        if not isinstance(d2, dict):
+            assert False, f"At {path}, d1 is a dict, d2 is not"
+        for key in set(d1) | set(d2):
+            dcompare(d1.get(key, None), d2.get(key, None), f"{path}/{key}")
+    else:
+        assert d1 == d2, f"Mismatch at {path}. d1={d1}, d2={d2}"


### PR DESCRIPTION
Hope this looks OK to you

    Renders em and strong text with style={"display":"inline"}. (Both still displayed as dmc.Text() - I've not used html.Em etc.)
    Displays nested lists
    Implements standard markdown image link format, displaying the image at its original size

I've also added a few unit tests for these features. Hoping the approach I've used OK for you - they convert the output of parse back to a dict and compare it with expected output
